### PR TITLE
Fix popup UI priority when using Inspect Element

### DIFF
--- a/src/components/TaskPopup/TaskPopup.module.css
+++ b/src/components/TaskPopup/TaskPopup.module.css
@@ -71,6 +71,10 @@
   max-width: 100%;
 }
 
+#popup > section {
+  background-color: inherit;
+}
+
 #popupContainer {
   left: 0;
   top: 0;


### PR DESCRIPTION
## Description
<!-- What does this pull request do? -->
This issue fixes a bug where the backlog takes UI priority over the issue viewer.

## Issues addressed
<!-- Please list every issue that is related to this pull request -->
<!-- There MUST be an issue for every pull request. -->
* #31 

## Completion criteria
<!-- Please list what you need to do to complete the implementation -->
* [x] The backlog should be hidden while the issue viewer is open.

## Test checks
- [x] To my knowledge, this is not a duplicate pull request.
- [x] My pull request works on the latest stable version of the following browsers:
  - [x] Microsoft Edge
  - [ ] Google Chrome
  - [x] Mozilla Firefox
  - [ ] Microsoft Edge Android