### PR TITLE
Only create one "Personal" project when initializing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import "./global.css";
 import Header from "./components/Header/Header";
 import Backlog from "./components/Backlog/Backlog";
 import TaskPopup from "./components/TaskPopup/TaskPopup";
-import { Navigate, Route, Routes, matchPath, useLocation, useNavigate, useParams } from "react-router-dom";
+import { Navigate, Route, Routes, matchPath, useLocation } from "react-router-dom";
 import Task from "./client/Task";
 import Project from "./client/Project";
 import SettingsPage from "./components/SettingsPage/SettingsPage";
@@ -18,18 +18,29 @@ export type SetState<T> = Dispatch<SetStateAction<T>>;
 export default function App() {
 
   const [client, setClient] = useState<Client | null>(null);
+  const [isReady, setIsReady] = useState<boolean>(false);
+
+  useEffect(() => {
+
+    const client = new Client();
+    setClient(client);
+
+  }, []);
 
   useEffect(() => {
 
     (async () => {
      
-      const client = new Client();
-      await client.initialize();
-      setClient(client);
+      if (client) {
+        
+        await client.initialize();
+        setIsReady(true);
+
+      }
       
     })();
 
-  }, []);
+  }, [client]);
 
   const [task, setTask] = useState<Task | null>(null);
   const [isTaskPopupOpen, setIsTaskPopupOpen] = useState<boolean>(false);
@@ -57,7 +68,7 @@ export default function App() {
 
   const [currentProject, setCurrentProject] = useState<Project | null>(null);
   const [documentTitle, setDocumentTitle] = useState<string>("Planzea");
-  return client ? (
+  return client && isReady ? (
     <>
       {task && currentProject ? <TaskPopup project={currentProject} client={client} onUpdate={(newTask) => setTask(newTask)} task={task} isOpen={isTaskPopupOpen} onClose={() => setTask(null)} /> : null}
       <LabelRemovalPopup client={client} documentTitle={documentTitle} project={currentProject} setCurrentProject={setCurrentProject} />

--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -304,18 +304,16 @@ export default class Client {
   async initialize(): Promise<void> {
 
     // Make sure the user has a personal project.
-    let personalProjectId = await this.#db.settings.get("personalProjectId");
+    const personalProjectId = this.personalProjectId ?? await this.#db.settings.get("personalProjectId");
 
     if (!personalProjectId) {
 
       // Create a personal project.
       const personalProject = await this.createProject({name: "Personal"});
       this.#db.settings.put(personalProject.id, "personalProjectId");
-      personalProjectId = personalProject.id;
+      this.personalProjectId = personalProject.id;
 
     }
-
-    this.personalProjectId = personalProjectId;
     
   }
 


### PR DESCRIPTION
## Description
<!-- What does this pull request do? -->
This pull request fixes an issue that caused the app to create two Personal projects when the app first runs.

## Issues addressed
<!-- Please list every issue that is related to this pull request -->
<!-- There MUST be an issue for every pull request. -->
* #42 

## Completion criteria
<!-- Please list what you need to do to complete the implementation -->
* [x] Only create one "Personal" project when initializing.

## Test checks
- [x] To my knowledge, this is not a duplicate pull request.
- [x] My pull request works on the latest stable version of the following browsers:
  - [ ] Microsoft Edge
  - [ ] Google Chrome
  - [x] Mozilla Firefox
  - [ ] Microsoft Edge Android