### PR TITLE
Hide search results on outside click

### DIFF
--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect, useState } from "react";
+import React, { ReactElement, useEffect, useRef, useState } from "react";
 import Project from "../../client/Project";
 import Task from "../../client/Task";
 import { useNavigate } from "react-router-dom";
@@ -79,7 +79,6 @@ export default function Search({client, onMobileSearchChange}: {client: CacheCli
     };
 
   }, [client]);
-
 
   const [query, setQuery] = useState<string>("");
   const navigate = useNavigate();
@@ -246,20 +245,45 @@ export default function Search({client, onMobileSearchChange}: {client: CacheCli
 
   }, [isOpen]);
 
+  const [areResultsShown, setAreResultsShown] = useState<boolean>(false);
+  const searchContainerRef = useRef<HTMLElement>(null);
+  useEffect(() => {
+
+    const checkForOutsideClick = (event: MouseEvent) => {
+
+      if (event.target && !searchContainerRef.current?.contains(event.target as Node)) {
+
+        setAreResultsShown(false);
+
+      }
+
+    };
+
+    window.addEventListener("click", checkForOutsideClick);
+
+    return () => window.removeEventListener("click", checkForOutsideClick);
+
+  }, []);
+
   return (
     <section className={isOpen ? styles.open : undefined}>
       <button id={styles.searchButton} onClick={() => setIsOpen(true)}>
         <Icon name="search" />
       </button>
-      <section>
+      <section ref={searchContainerRef}>
         <section id={styles.inputContainer}>
-          <input id={styles.input} type="text" placeholder="Search" value={query} onChange={({target: {value}}) => setQuery(value)} />
+          <input id={styles.input} onClick={() => setAreResultsShown(true)} type="text" placeholder="Search" value={query} onChange={({target: {value}}) => {
+            
+            setAreResultsShown(true);
+            setQuery(value);
+          
+          }} />
           <button id={styles.closeButton} onClick={() => setIsOpen(false)}>
             <Icon name="close" />
           </button>
         </section>
         {
-          results ? (
+          results && areResultsShown ? (
             <section id={styles.resultContainer}>
               {resultComponents[0] ? resultComponents : <p>Couldn't find anything</p>}
             </section>


### PR DESCRIPTION
<!-- What does this pull request do? -->
This pull request makes the app hide search results if the user clicks outside of the search area.

<!-- Please list every issue that is related to this pull request -->
<!-- There MUST be an issue for every pull request. -->
```[tasklist]
### Issues addressed
- [ ] #82
```

<!-- Please list what you need to do to complete the implementation -->
```[tasklist]
### Acceptance criteria for reviewers
- [x] Hide the results if the user clicks out of the search area
- [x] Show the results again if the user clicks back into the search area, or changes the query
```

```[tasklist]
### Browser checks
- [x] Microsoft Edge
- [ ] Microsoft Edge Android
- [ ] Google Chrome
- [x] Mozilla Firefox
- [x] Mozilla Firefox Android
```
