### PR TITLE
Remove double tap requirement to open projects and tasks on mobile screens

### DIFF
--- a/src/components/Backlog/Backlog.tsx
+++ b/src/components/Backlog/Backlog.tsx
@@ -142,7 +142,7 @@ export default function Backlog({client, setCurrentProject, setDocumentTitle}: {
             <section id={styles.taskListContainer}>
               <ul id={styles.taskList}>
                 {
-                  tasks.filter((task) => !task.parentTaskId).map((task) => <BacklogTask key={task.id} task={task} project={project} isSelected={taskSelection?.task.id === task.id} onClick={() => {
+                  tasks.map((task) => <BacklogTask key={task.id} task={task} project={project} isSelected={taskSelection?.task.id === task.id} onClick={() => {
                     
                     const newTaskSelection = {task, time: new Date().getTime()};
                     client.setSelectedTasks([newTaskSelection.task]);

--- a/src/components/BacklogTask/BacklogTask.tsx
+++ b/src/components/BacklogTask/BacklogTask.tsx
@@ -59,9 +59,25 @@ export default function BacklogTask({task, project, isSelected, onClick}: Backlo
   const dueDate = task.dueDate ? new Date(task.dueDate) : undefined;
   const dueMonth = dueDate ? ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"][dueDate.getMonth()] : undefined;
 
+  // Keep track of touch times.
+  const [touchStartTime, setTouchStartTime] = useState<number>(0);
+
   return (
     <li>
-      <section className={`${styles.task}${isSelected ? ` ${styles.selected}` : ""}`} onClick={onClick}>
+      <section className={`${styles.task}${isSelected ? ` ${styles.selected}` : ""}`} onClick={onClick} onTouchStart={() => setTouchStartTime(new Date().getTime())} onTouchEnd={() => {
+
+        const touchEndTime = new Date().getTime();
+
+        if (touchEndTime - touchStartTime <= 500) {
+
+          onClick();
+          onClick();
+
+        }
+
+        setTouchStartTime(0);
+
+      }}>
         <span>
           <section className={styles.statusContainer} onClick={(event) => event.stopPropagation()}>
             <button className={styles.status} onClick={() => setIsStatusSelectorOpen(!isStatusSelectorOpen)} ref={statusButtonRef} style={{backgroundColor: statusHexBG}} />

--- a/src/components/ProjectListButton/ProjectListButton.tsx
+++ b/src/components/ProjectListButton/ProjectListButton.tsx
@@ -1,13 +1,29 @@
-import React from "react";
+import React, { useState } from "react";
 import Project from "../../client/Project";
 import Icon from "../Icon/Icon";
 import styles from "./ProjectListButton.module.css";
 
 export default function ProjectListButton({project, isSelected, onClick}: {project: Project; isSelected: boolean; onClick: () => void}) {
 
+  // Keep track of touch times.
+  const [touchStartTime, setTouchStartTime] = useState<number>(0);
+
   return (
     <li>
-      <section className={`${styles.project}${isSelected ? ` ${styles.selected}` : ""}`} onClick={onClick}>
+      <section className={`${styles.project}${isSelected ? ` ${styles.selected}` : ""}`} onClick={onClick} onTouchStart={() => setTouchStartTime(new Date().getTime())} onTouchEnd={() => {
+
+        const touchEndTime = new Date().getTime();
+
+        if (touchEndTime - touchStartTime <= 500) {
+
+          onClick();
+          onClick();
+
+        }
+
+        setTouchStartTime(0);
+
+      }}>
         <span>
           <Icon name="folder" />
           <span>


### PR DESCRIPTION
<!-- What does this pull request do? -->
This pull request removes the requirement to tap a project/task twice to open it.

<!-- Please list every issue that is related to this pull request -->
<!-- There MUST be an issue for every pull request. -->
```[tasklist]
### Issues addressed
- [ ] #60
```

<!-- Please list what you need to do to complete the implementation -->
```[tasklist]
### Acceptance criteria for reviewers
- [x] Open the backlog when the user touches and releases a project button on the home page.
- [x] Open a task when the user touches and releases a task button on the backlog.
```

```[tasklist]
### Browser checks
- [x] Microsoft Edge
- [ ] Microsoft Edge Android
- [ ] Google Chrome
- [x] Mozilla Firefox
- [x] Mozilla Firefox Android
```
