### PR TITLE
Close popups on outside click

### DIFF
--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, RefObject, useEffect, useState } from "react";
+import React, { ReactElement, RefObject, useEffect, useRef, useState } from "react";
 import styles from "./Popup.module.css";
 import Icon from "../Icon/Icon";
 
@@ -16,6 +16,7 @@ interface PopupProperties {
 export default function Popup({name, isOpen, onClose, maxWidth, children, actions, popupContainerRef, popupContentPadding}: PopupProperties) {
 
   const [isShown, setIsShown] = useState<boolean>(false);
+  const [isBackgroundMouseDown, setIsBackgroundMouseDown] = useState<boolean>(false);
 
   useEffect(() => {
 
@@ -23,8 +24,12 @@ export default function Popup({name, isOpen, onClose, maxWidth, children, action
 
   }, [isOpen]);
 
+  const stopPropagation = (event: React.MouseEvent) => event.stopPropagation();
+
+  const ref = popupContainerRef ?? useRef<HTMLElement>(null);
+
   return (
-    <section ref={popupContainerRef} id={styles.popupContainer} className={isShown ? styles.open : undefined} onTransitionEnd={() => {
+    <section ref={ref} onMouseDown={() => setIsBackgroundMouseDown(true)} onMouseUp={(event) => isBackgroundMouseDown && event.target === ref?.current ? setIsShown(false) : setIsBackgroundMouseDown(false)} id={styles.popupContainer} className={isShown ? styles.open : undefined} onTransitionEnd={() => {
       
       if (!isShown) {
 
@@ -35,7 +40,7 @@ export default function Popup({name, isOpen, onClose, maxWidth, children, action
     }}>
       <section id={styles.popup} style={maxWidth ? {
         "--popup-width-max": `${maxWidth}px`
-      } as React.CSSProperties : undefined}>
+      } as React.CSSProperties : undefined} onMouseDown={stopPropagation} onMouseUp={stopPropagation}>
         <section id={styles.popupHeader}>
           {
             name ? (


### PR DESCRIPTION
<!-- What does this pull request do? -->
This pull request edits popups to close if the user clicks on the popup container background.

<!-- Please list every issue that is related to this pull request -->
<!-- There MUST be an issue for every pull request. -->
```[tasklist]
### Issues addressed
- [ ] #34 
```

<!-- Please list what you need to do to complete the implementation -->
```[tasklist]
### Acceptance criteria for reviewers
- [x] If the user clicks on the outside of a popup, close the popup.
```

```[tasklist]
### Browser checks
- [x] Microsoft Edge
- [ ] Microsoft Edge Android
- [ ] Google Chrome
- [x] Mozilla Firefox
- [x] Mozilla Firefox Android
```
